### PR TITLE
[Feat] 농업 재해보험 엔티티 생성 및 데이터 insert

### DIFF
--- a/backend/src/main/java/com/project/backend/insurances/domain/Insurance.java
+++ b/backend/src/main/java/com/project/backend/insurances/domain/Insurance.java
@@ -1,0 +1,43 @@
+package com.project.backend.insurances.domain;
+
+import com.project.backend.global.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "insurance")
+public class Insurance extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long insuranceId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private InsuranceConditionType insuranceConditionType;
+
+    private String insuranceCoverage;
+
+    private String insuranceDisaster;
+
+    private String insuranceVariety;
+
+    private String insurancePurpose;
+
+    private String insuranceStartDate;
+
+    private String insuranceEndDate;
+
+    private String insurancePaymentReason;
+
+    private Integer insuranceGovernmentSupportMin;
+
+    private Integer insuranceGovernmentSupportMax;
+
+    private Integer insuranceLocalGovernmentSupportMin;
+
+    private Integer insuranceLocalGovernmentSupportMax;
+}

--- a/backend/src/main/java/com/project/backend/insurances/domain/InsuranceConditionType.java
+++ b/backend/src/main/java/com/project/backend/insurances/domain/InsuranceConditionType.java
@@ -1,0 +1,6 @@
+package com.project.backend.insurances.domain;
+
+public enum InsuranceConditionType {
+    보통약관,
+    특별약관
+}


### PR DESCRIPTION
## 📄 작업 내용 요약
[농업정책보험금융원](https://www.apfs.kr/front/contents/sub.do?contId=55&menuId=5325#;)
데이터 363건 insert

## 📎 Issue 번호
<!-- closed #번호 -->
#2 
